### PR TITLE
Added missing return type

### DIFF
--- a/account/src/main/java/com/redhat/bankdemo/model/Account.java
+++ b/account/src/main/java/com/redhat/bankdemo/model/Account.java
@@ -69,7 +69,7 @@ public class Account implements Serializable {
     return beginBalance;
   }
 
-  public  getBeginBalanceTimeStamp() {
+  public Date getBeginBalanceTimeStamp() {
     return beginBalanceTimeStamp;
   }
 


### PR DESCRIPTION
The project would fail to build in lab 5 step 3 because
Account.getBeginBalanceTimestamp() was missing its return type.